### PR TITLE
Readme example hoists PreferAssertj instead of AssertJPrimitiveComparison

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ dependencies {
 
 tasks.withType(JavaCompile) {
   options.errorprone.errorproneArgs += [
-    '-Xep:AssertJPrimitiveComparison:ERROR',
+    '-Xep:PreferAssertj:ERROR',
     // ... include other rules too
   ]
 }


### PR DESCRIPTION
==COMMIT_MSG==
This example is more likely to be directly useful. In some internal
projects we validate that AssertJ is used instead of org.junit (and
friends) but we don't block pre-merge on assertions that can be
cleaned up. This way developers don't become annoyed writing tests.
==COMMIT_MSG==

