### PR TITLE
AssertjRefactoring ServiceLoader uses the correct classloader

### DIFF
--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjRefactoring.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjRefactoring.java
@@ -142,10 +142,11 @@ public final class AssertjRefactoring extends BugChecker
                 BugChecker.WildcardTreeMatcher {
 
     private static final ImmutableList<AssertjChecker> discoveredChecks =
-            ImmutableList.copyOf(ServiceLoader.load(AssertjChecker.class));
+            ImmutableList.copyOf(ServiceLoader.load(AssertjChecker.class, AssertjRefactoring.class.getClassLoader()));
 
     private final AssertjChecker[] checks;
 
+    @SuppressWarnings("unused") // Required by ServiceLoader
     public AssertjRefactoring() {
         this(discoveredChecks.toArray(new AssertjChecker[0]));
     }


### PR DESCRIPTION
Fixes a bug preventing `AssertjRefactoring` from being applied
in standard usage.

==COMMIT_MSG==
AssertjRefactoring ServiceLoader uses the correct classloader
==COMMIT_MSG==

No changelog: This bug has not been released.

