### PR TITLE
Add isEmpty String error prone check

### DIFF
--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjEmptyAssert.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjEmptyAssert.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.assertj.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.Iterables;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.ChildMultiMatcher;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.List;
+import java.util.Optional;
+
+@AutoService(AssertjChecker.class)
+public final class AssertjEmptyAssert implements AssertjChecker {
+
+    private static final String DESCRIPTION =
+            "Prefer using AssertJ isEmpty/isNotEmpty matchers instead of equality checks with a constant \"\".";
+
+    private static final Matcher<ExpressionTree> stringEqualMatcher = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.assertj.core.api.AbstractStringAssert")
+            .named("isEqualTo");
+
+    private static final Matcher<ExpressionTree> stringNotEqualMatcher = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.assertj.core.api.AbstractStringAssert")
+            .named("isNotEqualTo");
+
+    private static final Matcher<ExpressionTree> empty =
+            Matchers.ignoreParens(Matchers.stringLiteral(""));
+
+    private static final Matcher<ExpressionTree> matcher = Matchers.methodInvocation(
+            Matchers.anyOf(stringEqualMatcher, stringNotEqualMatcher),
+            ChildMultiMatcher.MatchType.LAST,
+            Matchers.anyOf(empty));
+
+    @Override
+    public Optional<AssertjCheckerResult> matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!matcher.matches(tree, state)) {
+            return Optional.empty();
+        }
+        List<? extends ExpressionTree> arguments = tree.getArguments();
+        if (arguments.size() != 1) {
+            return Optional.empty();
+        }
+        ExpressionTree argument = Iterables.getOnlyElement(arguments);
+        boolean expectEmpty = stringEqualMatcher.matches(tree, state);
+        return Optional.of(AssertjCheckerResult.builder()
+                .description(DESCRIPTION)
+                .fix(SuggestedFix.builder()
+                        .merge(SuggestedFixes.renameMethodInvocation(tree, expectEmpty ? "isEmpty" : "isNotEmpty",
+                                state))
+                        .replace(argument, "")
+                        .build())
+                .build());
+    }
+}

--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjEmptyAssert.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjEmptyAssert.java
@@ -44,8 +44,7 @@ public final class AssertjEmptyAssert implements AssertjChecker {
             .onDescendantOf("org.assertj.core.api.AbstractStringAssert")
             .named("isNotEqualTo");
 
-    private static final Matcher<ExpressionTree> empty =
-            Matchers.ignoreParens(Matchers.stringLiteral(""));
+    private static final Matcher<ExpressionTree> empty = Matchers.ignoreParens(Matchers.stringLiteral(""));
 
     private static final Matcher<ExpressionTree> matcher = Matchers.methodInvocation(
             Matchers.anyOf(stringEqualMatcher, stringNotEqualMatcher),
@@ -66,8 +65,8 @@ public final class AssertjEmptyAssert implements AssertjChecker {
         return Optional.of(AssertjCheckerResult.builder()
                 .description(DESCRIPTION)
                 .fix(SuggestedFix.builder()
-                        .merge(SuggestedFixes.renameMethodInvocation(tree, expectEmpty ? "isEmpty" : "isNotEmpty",
-                                state))
+                        .merge(SuggestedFixes.renameMethodInvocation(
+                                tree, expectEmpty ? "isEmpty" : "isNotEmpty", state))
                         .replace(argument, "")
                         .build())
                 .build());

--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjEmptyAssert.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjEmptyAssert.java
@@ -37,11 +37,11 @@ public final class AssertjEmptyAssert implements AssertjChecker {
             "Prefer using AssertJ isEmpty/isNotEmpty matchers instead of equality checks with a constant \"\".";
 
     private static final Matcher<ExpressionTree> stringEqualMatcher = MethodMatchers.instanceMethod()
-            .onDescendantOf("org.assertj.core.api.AbstractStringAssert")
+            .onDescendantOf("org.assertj.core.api.AbstractCharSequenceAssert")
             .named("isEqualTo");
 
     private static final Matcher<ExpressionTree> stringNotEqualMatcher = MethodMatchers.instanceMethod()
-            .onDescendantOf("org.assertj.core.api.AbstractStringAssert")
+            .onDescendantOf("org.assertj.core.api.AbstractCharSequenceAssert")
             .named("isNotEqualTo");
 
     private static final Matcher<ExpressionTree> empty = Matchers.ignoreParens(Matchers.stringLiteral(""));

--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjEmptyStringAssert.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjEmptyStringAssert.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Optional;
 
 @AutoService(AssertjChecker.class)
-public final class AssertjEmptyAssert implements AssertjChecker {
+public final class AssertjEmptyStringAssert implements AssertjChecker {
 
     private static final String DESCRIPTION =
             "Prefer using AssertJ isEmpty/isNotEmpty matchers instead of equality checks with a constant \"\".";

--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjEmptyAssertTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjEmptyAssertTest.java
@@ -68,6 +68,6 @@ class AssertjEmptyAssertTest {
     }
 
     private RefactoringValidator test() {
-        return RefactoringValidator.of(new AssertjRefactoring(new AssertjEmptyAssert()), getClass());
+        return RefactoringValidator.of(new AssertjRefactoring(new AssertjEmptyStringAssert()), getClass());
     }
 }

--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjEmptyAssertTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjEmptyAssertTest.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.assertj.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.jupiter.api.Test;
+
+class AssertjEmptyAssertTest {
+
+    @Test
+    public void fix_isEmpty() {
+        test().addInputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str).isEqualTo(\"\");",
+                        "    assertThat(str).describedAs(\"desc\").isEqualTo(\"\");",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str).isEmpty();",
+                        "    assertThat(str).describedAs(\"desc\").isEmpty();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_isNotEmpty() {
+        test().addInputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str).isNotEqualTo(\"\");",
+                        "    assertThat(str).describedAs(\"desc\").isNotEqualTo(\"\");",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(String str) {",
+                        "    assertThat(str).isNotEmpty();",
+                        "    assertThat(str).describedAs(\"desc\").isNotEmpty();",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    private RefactoringValidator test() {
+        return RefactoringValidator.of(new AssertjRefactoring(new AssertjEmptyAssert()), getClass());
+    }
+}

--- a/changelog/@unreleased/pr-15.v2.yml
+++ b/changelog/@unreleased/pr-15.v2.yml
@@ -1,15 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    Add isEmpty String error prone check
-
-    ## Before this PR
-    isEqualTo("") and isNotEqualTo("") are allowed
-
-    ## After this PR
-    They are changed to isEmpty() and isNotEmpty()
-
-    ## Possible downsides?
-    isEmpty also checks null, so we are now matching another case. I'm guessing that assertThat(aNullString).isNotEqualTo("") was a bug to begin with though.
+    AssertjRefactoring rewrites assertThat(string).isEqualTo("") as assertThat(string).isEmpty()
   links:
   - https://github.com/palantir/assertj-automation/pull/15

--- a/changelog/@unreleased/pr-15.v2.yml
+++ b/changelog/@unreleased/pr-15.v2.yml
@@ -1,0 +1,15 @@
+type: improvement
+improvement:
+  description: |-
+    Add isEmpty String error prone check
+
+    ## Before this PR
+    isEqualTo("") and isNotEqualTo("") are allowed
+
+    ## After this PR
+    They are changed to isEmpty() and isNotEmpty()
+
+    ## Possible downsides?
+    isEmpty also checks null, so we are now matching another case. I'm guessing that assertThat(aNullString).isNotEqualTo("") was a bug to begin with though.
+  links:
+  - https://github.com/palantir/assertj-automation/pull/15


### PR DESCRIPTION
## Before this PR
isEqualTo("") and isNotEqualTo("") are allowed

## After this PR
They are changed to isEmpty() and isNotEmpty()

## Possible downsides?
isEmpty also checks null, so we are now matching another case. I'm guessing that assertThat(aNullString).isNotEqualTo("") was a bug to begin with though.

