### PR TITLE
Add check for replacing try-catch-fail with assertThatThrownBy

### DIFF
--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownBy.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownBy.java
@@ -108,8 +108,9 @@ public final class AssertjAssertThatThrownBy extends BugChecker implements BugCh
                 ((JCTree) throwingStatements.iterator().next()).getStartPosition(),
                 "assertThatThrownBy(() -> {");
         StringBuilder postFix = new StringBuilder();
-        postFix.append(String.format("}).isInstanceOf(%s.class)", state.getSourceForNode(catchParameter.getType())));
+        postFix.append("})");
         failMessage.ifPresent(msg -> postFix.append(String.format(".describedAs(%s)", msg)));
+        postFix.append(String.format(".isInstanceOf(%s.class)", state.getSourceForNode(catchParameter.getType())));
         postFix.append(";");
         fix.postfixWith(Iterables.getLast(throwingStatements), postFix.toString());
         fix.replace(state.getEndPosition(Iterables.getLast(throwingStatements)), state.getEndPosition(tree), "");

--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownBy.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownBy.java
@@ -1,0 +1,118 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.assertj.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.CatchTree;
+import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.TryTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.List;
+import java.util.Optional;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        name = "AssertjAssertThatThrownBy",
+        link = "https://github.com/palantir/assertj-automation",
+        linkType = BugPattern.LinkType.CUSTOM,
+        providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
+        severity = BugPattern.SeverityLevel.SUGGESTION,
+        summary = "Prefer AssertJ assertThatThrownBy assertions over try-catch with fail statements")
+public final class AssertjAssertThatThrownBy extends BugChecker implements BugChecker.TryTreeMatcher {
+    private static final ImmutableList<String> IGNORED_FAIL_MESSAGES = ImmutableList.of("\"fail\"", "\"\"");
+
+    private static final Matcher<StatementTree> FAIL_METHOD = Matchers.anyOf(
+            Matchers.expressionStatement(
+                    MethodMatchers.staticMethod().onClass("org.junit.Assert").named("fail")),
+            Matchers.expressionStatement(MethodMatchers.staticMethod()
+                    .onClass("org.junit.jupiter.api.Assertions")
+                    .named("fail")),
+            Matchers.expressionStatement(MethodMatchers.staticMethod()
+                    .onClass("org.assertj.core.api.Assertions")
+                    .named("fail")));
+
+    @Override
+    public Description matchTry(TryTree tree, VisitorState state) {
+        List<? extends StatementTree> tryStatements = tree.getBlock().getStatements();
+        if (tryStatements.isEmpty() || tree.getCatches().size() != 1 || tree.getFinallyBlock() != null) {
+            return Description.NO_MATCH;
+        }
+        CatchTree catchTree = Iterables.getOnlyElement(tree.getCatches());
+        if (!catchTree.getBlock().getStatements().isEmpty()
+                || catchTree.getParameter().getType().getKind() == Tree.Kind.UNION_TYPE) {
+            return Description.NO_MATCH;
+        }
+        StatementTree lastStatement = Iterables.getLast(tryStatements);
+        List<? extends StatementTree> throwingStatements = tryStatements.subList(0, tryStatements.size() - 1);
+        if (!FAIL_METHOD.matches(lastStatement, state) || throwingStatements.isEmpty()) {
+            return Description.NO_MATCH;
+        }
+        if (!TestCheckUtils.isTestCode(state)) {
+            return Description.NO_MATCH;
+        }
+        Optional<String> failMessage = getFailMessage(lastStatement, state);
+        return buildDescription(tree)
+                .addFix(tryFailToAssertThatThrownBy(
+                        tree, throwingStatements, catchTree.getParameter(), failMessage, state))
+                .build();
+    }
+
+    private static Optional<String> getFailMessage(StatementTree failStatement, VisitorState state) {
+        Iterable<? extends ExpressionTree> failArgs =
+                ((MethodInvocationTree) ((ExpressionStatementTree) failStatement).getExpression()).getArguments();
+        return Optional.ofNullable(Iterables.get(failArgs, 0, null))
+                .map(state::getSourceForNode)
+                .filter(msg -> !IGNORED_FAIL_MESSAGES.contains(msg));
+    }
+
+    private static Optional<Fix> tryFailToAssertThatThrownBy(
+            TryTree tree,
+            List<? extends StatementTree> throwingStatements,
+            VariableTree catchParameter,
+            Optional<String> failMessage,
+            VisitorState state) {
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        fix.addStaticImport("org.assertj.core.api.Assertions.assertThatThrownBy");
+        fix.replace(
+                ((JCTree) tree).getStartPosition(),
+                ((JCTree) throwingStatements.iterator().next()).getStartPosition(),
+                "assertThatThrownBy(() -> {");
+        StringBuilder postFix = new StringBuilder();
+        postFix.append(String.format("}).isInstanceOf(%s.class)", state.getSourceForNode(catchParameter.getType())));
+        failMessage.ifPresent(msg -> postFix.append(String.format(".describedAs(%s)", msg)));
+        postFix.append(";");
+        fix.postfixWith(Iterables.getLast(throwingStatements), postFix.toString());
+        fix.replace(state.getEndPosition(Iterables.getLast(throwingStatements)), state.getEndPosition(tree), "");
+        return Optional.of(fix.build());
+    }
+}

--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
@@ -49,9 +49,7 @@ public class AssertjAssertThatThrownByTest {
                         "class MyClass {",
                         "  @Test",
                         "  void foo() {",
-                        "    assertThatThrownBy(() -> {",
-                        "      System.out.println();",
-                        "    }).isInstanceOf(RuntimeException.class);",
+                        "    assertThatThrownBy(() -> System.out.println()).isInstanceOf(RuntimeException.class);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -125,11 +123,8 @@ public class AssertjAssertThatThrownByTest {
                         "class MyClass {",
                         "  @Test",
                         "  void foo() {",
-                        "    assertThatThrownBy(() -> {",
-                        "      System.out.println();",
-                        "    })",
-                        "    .describedAs(\"My error message.\")",
-                        "    .isInstanceOf(RuntimeException.class);",
+                        "    assertThatThrownBy(() -> System.out.println()).describedAs(\"My error message.\")"
+                                + ".isInstanceOf(RuntimeException.class);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -165,11 +160,8 @@ public class AssertjAssertThatThrownByTest {
                         "class MyClass {",
                         "  @Test",
                         "  void foo() {",
-                        "    assertThatThrownBy(() -> {",
-                        "      System.out.println();",
-                        "    })",
-                        "    .describedAs(\"My error message.\")",
-                        "    .isInstanceOf(RuntimeException.class);",
+                        "    assertThatThrownBy(() -> System.out.println()).describedAs(\"My error message.\")"
+                                + ".isInstanceOf(RuntimeException.class);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
@@ -1,0 +1,263 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.assertj.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.jupiter.api.Test;
+
+public class AssertjAssertThatThrownByTest {
+
+    @Test
+    public void fix_with_single_throwing_statement() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    try {",
+                        "      System.out.println();",
+                        "      fail(\"fail\");",
+                        "    } catch (RuntimeException expected) {}",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "MyClass.java",
+                        "import static org.assertj.core.api.Assertions.assertThatThrownBy;",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    assertThatThrownBy(() -> {",
+                        "      System.out.println();",
+                        "    }).isInstanceOf(RuntimeException.class);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_with_multiple_throwing_statements() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    try {",
+                        "      System.out.println(\"1\");",
+                        "      System.out.println(\"2\");",
+                        "      System.out.println(\"3\");",
+                        "      fail(\"fail\");",
+                        "    } catch (RuntimeException expected) {}",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "MyClass.java",
+                        "import static org.assertj.core.api.Assertions.assertThatThrownBy;",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    assertThatThrownBy(() -> {",
+                        "      System.out.println(\"1\");",
+                        "      System.out.println(\"2\");",
+                        "      System.out.println(\"3\");",
+                        "    }).isInstanceOf(RuntimeException.class);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_while_preserving_fail_message() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    try {",
+                        "      System.out.println();",
+                        "      fail(\"My error message.\");",
+                        "    } catch (RuntimeException expected) {}",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "MyClass.java",
+                        "import static org.assertj.core.api.Assertions.assertThatThrownBy;",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    assertThatThrownBy(() -> {",
+                        "      System.out.println();",
+                        "    })",
+                        "    .isInstanceOf(RuntimeException.class)",
+                        "    .describedAs(\"My error message.\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_with_comments_in_catch() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    try {",
+                        "      System.out.println();",
+                        "      fail(\"My error message.\");",
+                        "    } catch (RuntimeException expected) {",
+                        "        // expected",
+                        "    }",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "MyClass.java",
+                        "import static org.assertj.core.api.Assertions.assertThatThrownBy;",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    assertThatThrownBy(() -> {",
+                        "      System.out.println();",
+                        "    })",
+                        "    .isInstanceOf(RuntimeException.class)",
+                        "    .describedAs(\"My error message.\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void skip_empty_try() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    try {",
+                        "    } catch (IllegalArgumentException expected) {}",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void skip_multiple_catches() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    try {",
+                        "      System.out.println();",
+                        "      fail(\"fail\");",
+                        "    } catch (IllegalArgumentException expected) {",
+                        "    } catch (NullPointerException expected) {",
+                        "    }",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void skip_missing_fail_statement() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    try {",
+                        "      System.out.println();",
+                        "    } catch (IllegalArgumentException expected) {}",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void skip_only_fail_in_try() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    try {",
+                        "      fail(\"fail\");",
+                        "    } catch (IllegalArgumentException expected) {}",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+}

--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
@@ -128,8 +128,8 @@ public class AssertjAssertThatThrownByTest {
                         "    assertThatThrownBy(() -> {",
                         "      System.out.println();",
                         "    })",
-                        "    .isInstanceOf(RuntimeException.class)",
-                        "    .describedAs(\"My error message.\");",
+                        "    .describedAs(\"My error message.\")",
+                        "    .isInstanceOf(RuntimeException.class);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
@@ -168,8 +168,8 @@ public class AssertjAssertThatThrownByTest {
                         "    assertThatThrownBy(() -> {",
                         "      System.out.println();",
                         "    })",
-                        "    .isInstanceOf(RuntimeException.class)",
-                        "    .describedAs(\"My error message.\");",
+                        "    .describedAs(\"My error message.\")",
+                        "    .isInstanceOf(RuntimeException.class);",
                         "  }",
                         "}")
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);

--- a/build.gradle
+++ b/build.gradle
@@ -39,5 +39,6 @@ allprojects {
 }
 
 subprojects {
+    sourceCompatibility = 1.8
     apply plugin: 'org.inferred.processors'
 }

--- a/changelog/@unreleased/pr-70.v2.yml
+++ b/changelog/@unreleased/pr-70.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add check for replacing try-catch-fail with assertThatThrownBy
+  links:
+  - https://github.com/palantir/assertj-automation/pull/70


### PR DESCRIPTION
## After this PR

This PR adds an ErrorProne BugChecker to use an AssertJ `assertThatThrownBy`-lambda instead of try-catch-fail patterns.

For example given the test case:
```java
try {
  myThrowingMethod();
  fail("My fail message");
} catch (RuntimeException e) {
  // expected
}
```

The BugChecker will output the fix:
```java
assertThatThrownBy(() -> myThrowingMethod())
        .isInstanceOf(RuntimeException.class)
        .describedAs("My fail message");
```

In its current version, we only focus on simple try-catch-fail patterns. Meaning we skip cases that have:
* Multiple catch or a finally block.
* No or only a `fail()` statement in the try block.
* An empty try block.
* A catch block that is not empty.
* try-catch statements that are not in a test class.

## Possible downsides?

Currently we are not checking if the code inside the `try` block references outside code. In this case, the transformation is not correct because the variable is not final but referenced from inside a lambda.

```java
Iterator<String> iter = ...;
try {
  iter.next();
  fail("fail");
} catch (NoSuchElementException e) {}
```

