### PR TITLE
AssertjAssertThatThrownBy preserves 'try {' comments

### DIFF
--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
@@ -168,6 +168,45 @@ public class AssertjAssertThatThrownByTest {
     }
 
     @Test
+    public void fix_with_comments_in_try() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "    try {",
+                        "      // out is closed",
+                        "      System.out.println();",
+                        "      fail(\"My error message.\");",
+                        "    } catch (RuntimeException expected) {",
+                        "        // expected",
+                        "    }",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "MyClass.java",
+                        "import static org.assertj.core.api.Assertions.assertThatThrownBy;",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo() {",
+                        "      // out is closed",
+                        "    assertThatThrownBy(() -> System.out.println()).describedAs(\"My error message.\")"
+                                + ".isInstanceOf(RuntimeException.class);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
     public void skip_empty_try() {
         RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
                 .addInputLines(

--- a/changelog/@unreleased/pr-78.v2.yml
+++ b/changelog/@unreleased/pr-78.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: AssertjAssertThatThrownBy preserves 'try {' comments
+  links:
+  - https://github.com/palantir/assertj-automation/pull/78


### PR DESCRIPTION
Before:
```diff
- try {
-   // foo should bar
-   foo();
- catch (Bar) {
+ assertThatThrownBy(() -> foo()).isInstanceOf(Bar.class);
```
After:
```diff
- try {
-   // foo should bar
-   foo();
- catch (Bar) {
+ // foo should bar
+ assertThatThrownBy(() -> foo()).isInstanceOf(Bar.class);
```

==COMMIT_MSG==
AssertjAssertThatThrownBy preserves 'try {' comments
==COMMIT_MSG==

