### PR TITLE
AssertjAssertThatThrownBy doesn't produce code that won't compile

### DIFF
--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownBy.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownBy.java
@@ -25,6 +25,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
@@ -85,9 +86,10 @@ public final class AssertjAssertThatThrownBy extends BugChecker implements BugCh
             return Description.NO_MATCH;
         }
         Optional<String> failMessage = getFailMessage(lastStatement, state);
+        Fix fix = tryFailToAssertThatThrownBy(tree, throwingStatements, catchTree.getParameter(), failMessage, state);
+        boolean compiles = SuggestedFixes.compilesWithFix(fix, state, ImmutableList.of(), true);
         return buildDescription(tree)
-                .addFix(tryFailToAssertThatThrownBy(
-                        tree, throwingStatements, catchTree.getParameter(), failMessage, state))
+                .addFix(compiles ? Optional.of(fix) : Optional.empty())
                 .build();
     }
 

--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
@@ -291,4 +291,31 @@ public class AssertjAssertThatThrownByTest {
                 .expectUnchanged()
                 .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
     }
+
+    @Test
+    public void ignore_with_non_final_arguments() {
+        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
+                .addInputLines(
+                        "MyClass.java",
+                        "import static org.junit.Assert.fail;",
+                        "",
+                        "import org.junit.jupiter.api.Test;",
+                        "",
+                        "class MyClass {",
+                        "  @Test",
+                        "  void foo(boolean value) {",
+                        "    String st = \"foo\";",
+                        "    if (value) {",
+                        "        st = \"bar\";",
+                        "    }",
+                        "    // BUG: Diagnostic contains:",
+                        "    try {",
+                        "      System.out.println(st);",
+                        "      fail(\"fail\");",
+                        "    } catch (RuntimeException expected) {}",
+                        "  }",
+                        "}")
+                .expectUnchanged()
+                .doTest();
+    }
 }

--- a/changelog/@unreleased/pr-126.v2.yml
+++ b/changelog/@unreleased/pr-126.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: AssertjAssertThatThrownBy doesn't produce code that won't compile.
+    In these cases the check will fail, but it doesn't provide a broken fix.
+  links:
+  - https://github.com/palantir/assertj-automation/pull/126


### PR DESCRIPTION
## Before this PR
AssertjAssertThatThrownBy produced output that could not compile.

## After this PR
==COMMIT_MSG==
AssertjAssertThatThrownBy doesn't produce code that won't compile. In these cases the check will fail, but it doesn't provide a broken fix.
==COMMIT_MSG==

## Possible downsides?
SuggestedFixes.compilesWithFix is a _terrible_ idea in most cases
and has a significant performance impact.

