### PR TITLE
fix #80: Include AssertjAssertThatThrownBy in AssertjRefactoring

### DIFF
--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjCheckerResult.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjCheckerResult.java
@@ -17,15 +17,15 @@
 package com.palantir.assertj.errorprone;
 
 import com.google.common.base.Preconditions;
-import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.Fix;
 import java.util.Optional;
 
 final class AssertjCheckerResult {
 
     private final String description;
-    private final Optional<SuggestedFix> fix;
+    private final Optional<? extends Fix> fix;
 
-    private AssertjCheckerResult(String description, Optional<SuggestedFix> fix) {
+    private AssertjCheckerResult(String description, Optional<? extends Fix> fix) {
         this.description = description;
         this.fix = fix;
     }
@@ -34,7 +34,7 @@ final class AssertjCheckerResult {
         return description;
     }
 
-    Optional<SuggestedFix> fix() {
+    Optional<? extends Fix> fix() {
         return fix;
     }
 
@@ -72,7 +72,7 @@ final class AssertjCheckerResult {
     static final class Builder {
 
         private String description;
-        private Optional<SuggestedFix> fix = Optional.empty();
+        private Optional<? extends Fix> fix = Optional.empty();
 
         private Builder() {}
 
@@ -81,8 +81,13 @@ final class AssertjCheckerResult {
             return this;
         }
 
-        Builder fix(SuggestedFix value) {
+        Builder fix(Fix value) {
             this.fix = Optional.of(Preconditions.checkNotNull(value, "Fix is required"));
+            return this;
+        }
+
+        Builder fix(Optional<? extends Fix> value) {
+            this.fix = Preconditions.checkNotNull(value, "Fix is required");
             return this;
         }
 

--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjAssertThatThrownByTest.java
@@ -23,8 +23,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void fix_with_single_throwing_statement() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -57,8 +56,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void fix_with_multiple_throwing_statements() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -97,8 +95,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void fix_while_preserving_fail_message() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -132,8 +129,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void fix_with_comments_in_catch() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -169,8 +165,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void fix_with_comments_in_try() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -208,8 +203,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void skip_empty_try() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -228,8 +222,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void skip_multiple_catches() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -252,8 +245,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void skip_missing_fail_statement() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -273,8 +265,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void skip_only_fail_in_try() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -294,8 +285,7 @@ public class AssertjAssertThatThrownByTest {
 
     @Test
     public void ignore_with_non_final_arguments() {
-        RefactoringValidator.of(new AssertjAssertThatThrownBy(), getClass())
-                .addInputLines(
+        fix().addInputLines(
                         "MyClass.java",
                         "import static org.junit.Assert.fail;",
                         "",
@@ -317,5 +307,9 @@ public class AssertjAssertThatThrownByTest {
                         "}")
                 .expectUnchanged()
                 .doTest();
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(new AssertjRefactoring(new AssertjAssertThatThrownBy()), getClass());
     }
 }

--- a/changelog/@unreleased/pr-127.v2.yml
+++ b/changelog/@unreleased/pr-127.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Include AssertjAssertThatThrownBy in AssertjRefactoring
+  links:
+  - https://github.com/palantir/assertj-automation/pull/127


### PR DESCRIPTION
## Before this PR
AssertjAssertThatThrownBy was mostly unused.

## After this PR
==COMMIT_MSG==
Include AssertjAssertThatThrownBy in AssertjRefactoring
==COMMIT_MSG==

## Possible downsides?
compilesWithFix is expensive, fortunately we only run this in excavator by default, not per-merge in all projects.

