### PR TITLE
Increase severity level to WARNING

### DIFF
--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjRefactoring.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjRefactoring.java
@@ -84,7 +84,7 @@ import java.util.ServiceLoader;
         link = "https://github.com/palantir/assertj-automation",
         linkType = BugPattern.LinkType.CUSTOM,
         providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = BugPattern.SeverityLevel.WARNING,
         summary = "AssertJ statements may be refactored to be more readable or produce more helpful debugging "
                 + "information on failure.")
 public final class AssertjRefactoring extends BugChecker

--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/PreferAssertj.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/PreferAssertj.java
@@ -64,7 +64,7 @@ import javax.lang.model.type.TypeKind;
         link = "https://github.com/palantir/assertj-automation",
         linkType = BugPattern.LinkType.CUSTOM,
         providesFix = BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION,
-        severity = BugPattern.SeverityLevel.SUGGESTION,
+        severity = BugPattern.SeverityLevel.WARNING,
         summary = "Prefer AssertJ fluent assertions")
 public final class PreferAssertj extends BugChecker
         implements BugChecker.AssertTreeMatcher, BugChecker.MethodInvocationTreeMatcher {

--- a/changelog/@unreleased/pr-167.v2.yml
+++ b/changelog/@unreleased/pr-167.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The `assertj-error-prone` checks now have a severity of `WARNING`.
+  links:
+  - https://github.com/palantir/assertj-automation/pull/167


### PR DESCRIPTION
This enables users to enforce AssertJ usage with `-Werror` without having to manually change the severity.