### PR TITLE
Use canonical OptionalAssert methods

### DIFF
--- a/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalContains.java
+++ b/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalContains.java
@@ -24,7 +24,7 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Optional;
 
-public final class AssertjOptionalHasValue<T> {
+public final class AssertjOptionalContains<T> {
 
     @BeforeTemplate
     void before(Optional<T> optional, T innerValue) {
@@ -33,18 +33,29 @@ public final class AssertjOptionalHasValue<T> {
 
     @BeforeTemplate
     void before2(Optional<T> optional, T innerValue) {
+        assertThat(optional).isEqualTo(Optional.of(innerValue));
+    }
+
+    @BeforeTemplate
+    void before3(Optional<T> optional, T innerValue) {
         assertThat(optional.isPresent() && optional.get().equals(innerValue)).isTrue();
     }
 
     @BeforeTemplate
-    void redundantAssertion(Optional<T> optional, T innerValue) {
+    void redundantAssertion1(Optional<T> optional, T innerValue) {
         assertThat(optional).isPresent();
         assertThat(optional).hasValue(innerValue);
+    }
+
+    @BeforeTemplate
+    void redundantAssertion2(Optional<T> optional, T innerValue) {
+        assertThat(optional).isPresent();
+        assertThat(optional).contains(innerValue);
     }
 
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     void after(Optional<T> optional, T innerValue) {
-        assertThat(optional).hasValue(innerValue);
+        assertThat(optional).contains(innerValue);
     }
 }

--- a/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalContainsRedundantWithDescription.java
+++ b/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalContainsRedundantWithDescription.java
@@ -25,10 +25,10 @@ import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Optional;
 
-public final class AssertjOptionalHasValueRedundantWithDescription<T> {
+public final class AssertjOptionalContainsRedundantWithDescription<T> {
 
     @BeforeTemplate
-    void redundantAssertion(
+    void redundantAssertion1(
             Optional<T> optional,
             T innerValue,
             String description1,
@@ -37,6 +37,18 @@ public final class AssertjOptionalHasValueRedundantWithDescription<T> {
             @Repeated Object descriptionArgs2) {
         assertThat(optional).describedAs(description1, descriptionArgs1).isPresent();
         assertThat(optional).describedAs(description2, descriptionArgs2).hasValue(innerValue);
+    }
+
+    @BeforeTemplate
+    void redundantAssertion2(
+            Optional<T> optional,
+            T innerValue,
+            String description1,
+            @Repeated Object descriptionArgs1,
+            String description2,
+            @Repeated Object descriptionArgs2) {
+        assertThat(optional).describedAs(description1, descriptionArgs1).isPresent();
+        assertThat(optional).describedAs(description2, descriptionArgs2).contains(innerValue);
     }
 
     @AfterTemplate
@@ -49,6 +61,6 @@ public final class AssertjOptionalHasValueRedundantWithDescription<T> {
             @Repeated Object _descriptionArgs1,
             String description2,
             @Repeated Object descriptionArgs2) {
-        assertThat(optional).describedAs(description2, descriptionArgs2).hasValue(innerValue);
+        assertThat(optional).describedAs(description2, descriptionArgs2).contains(innerValue);
     }
 }

--- a/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalContainsWithDescription.java
+++ b/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalContainsWithDescription.java
@@ -25,15 +25,20 @@ import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Optional;
 
-public final class AssertjOptionalHasValueWithDescription<T> {
+public final class AssertjOptionalContainsWithDescription<T> {
 
     @BeforeTemplate
-    void before(Optional<T> optional, T innerValue, String description, @Repeated Object descriptionArgs) {
+    void before1(Optional<T> optional, T innerValue, String description, @Repeated Object descriptionArgs) {
         assertThat(optional.get()).describedAs(description, descriptionArgs).isEqualTo(innerValue);
     }
 
     @BeforeTemplate
     void before2(Optional<T> optional, T innerValue, String description, @Repeated Object descriptionArgs) {
+        assertThat(optional).describedAs(description, descriptionArgs).isEqualTo(Optional.of(innerValue));
+    }
+
+    @BeforeTemplate
+    void before3(Optional<T> optional, T innerValue, String description, @Repeated Object descriptionArgs) {
         assertThat(optional.isPresent() && optional.get().equals(innerValue))
                 .describedAs(description, descriptionArgs)
                 .isTrue();
@@ -42,6 +47,6 @@ public final class AssertjOptionalHasValueWithDescription<T> {
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     void after(Optional<T> optional, T innerValue, String description, @Repeated Object descriptionArgs) {
-        assertThat(optional).describedAs(description, descriptionArgs).hasValue(innerValue);
+        assertThat(optional).describedAs(description, descriptionArgs).contains(innerValue);
     }
 }

--- a/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalIsEmpty.java
+++ b/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalIsEmpty.java
@@ -24,7 +24,7 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Optional;
 
-public final class AssertjOptionalIsNotPresent<T> {
+public final class AssertjOptionalIsEmpty<T> {
 
     @BeforeTemplate
     void before1(Optional<T> thing) {
@@ -38,17 +38,27 @@ public final class AssertjOptionalIsNotPresent<T> {
 
     @BeforeTemplate
     void before3(Optional<T> thing) {
-        assertThat(thing).isEqualTo(Optional.empty());
+        assertThat(thing.isEmpty()).isTrue();
     }
 
     @BeforeTemplate
     void before4(Optional<T> thing) {
+        assertThat(!thing.isEmpty()).isFalse();
+    }
+
+    @BeforeTemplate
+    void before5(Optional<T> thing) {
+        assertThat(thing).isEqualTo(Optional.empty());
+    }
+
+    @BeforeTemplate
+    void before6(Optional<T> thing) {
         assertThat(Optional.empty()).isEqualTo(thing);
     }
 
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     void after(Optional<T> thing) {
-        assertThat(thing).isNotPresent();
+        assertThat(thing).isEmpty();
     }
 }

--- a/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalIsEmptyWithDescription.java
+++ b/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalIsEmptyWithDescription.java
@@ -25,7 +25,7 @@ import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Optional;
 
-public final class AssertjOptionalIsNotPresentWithDescription<T> {
+public final class AssertjOptionalIsEmptyWithDescription<T> {
 
     @BeforeTemplate
     void before1(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
@@ -39,17 +39,27 @@ public final class AssertjOptionalIsNotPresentWithDescription<T> {
 
     @BeforeTemplate
     void before3(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
-        assertThat(thing).describedAs(description, descriptionArgs).isEqualTo(Optional.empty());
+        assertThat(thing.isEmpty()).describedAs(description, descriptionArgs).isTrue();
     }
 
     @BeforeTemplate
     void before4(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
+        assertThat(!thing.isEmpty()).describedAs(description, descriptionArgs).isFalse();
+    }
+
+    @BeforeTemplate
+    void before5(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
+        assertThat(thing).describedAs(description, descriptionArgs).isEqualTo(Optional.empty());
+    }
+
+    @BeforeTemplate
+    void before6(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
         assertThat(Optional.empty()).describedAs(description, descriptionArgs).isEqualTo(thing);
     }
 
     @AfterTemplate
     @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     void after(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
-        assertThat(thing).describedAs(description, descriptionArgs).isNotPresent();
+        assertThat(thing).describedAs(description, descriptionArgs).isEmpty();
     }
 }

--- a/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalIsPresent.java
+++ b/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalIsPresent.java
@@ -27,8 +27,23 @@ import java.util.Optional;
 public final class AssertjOptionalIsPresent<T> {
 
     @BeforeTemplate
-    void before(Optional<T> thing) {
+    void before1(Optional<T> thing) {
         assertThat(thing.isPresent()).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(Optional<T> thing) {
+        assertThat(!thing.isPresent()).isFalse();
+    }
+
+    @BeforeTemplate
+    void before3(Optional<T> thing) {
+        assertThat(thing.isEmpty()).isFalse();
+    }
+
+    @BeforeTemplate
+    void before4(Optional<T> thing) {
+        assertThat(!thing.isEmpty()).isTrue();
     }
 
     @AfterTemplate

--- a/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalIsPresentWithDescription.java
+++ b/assertj-refaster-rules/src/main/java/com/palantir/assertj/refaster/AssertjOptionalIsPresentWithDescription.java
@@ -28,8 +28,23 @@ import java.util.Optional;
 public final class AssertjOptionalIsPresentWithDescription<T> {
 
     @BeforeTemplate
-    void before(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
+    void before1(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
         assertThat(thing.isPresent()).describedAs(description, descriptionArgs).isTrue();
+    }
+
+    @BeforeTemplate
+    void before2(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
+        assertThat(!thing.isPresent()).describedAs(description, descriptionArgs).isFalse();
+    }
+
+    @BeforeTemplate
+    void before3(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
+        assertThat(thing.isEmpty()).describedAs(description, descriptionArgs).isFalse();
+    }
+
+    @BeforeTemplate
+    void before4(Optional<T> thing, String description, @Repeated Object descriptionArgs) {
+        assertThat(!thing.isEmpty()).describedAs(description, descriptionArgs).isTrue();
     }
 
     @AfterTemplate

--- a/assertj-refaster-rules/src/test/java/com/palantir/assertj/refaster/AssertjOptionalContainsTest.java
+++ b/assertj-refaster-rules/src/test/java/com/palantir/assertj/refaster/AssertjOptionalContainsTest.java
@@ -21,14 +21,14 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import com.palantir.baseline.refaster.RefasterTestHelper;
 import org.junit.jupiter.api.Test;
 
-public final class AssertjOptionalHasValueTest {
+public final class AssertjOptionalContainsTest {
 
     @Test
     public void test() {
         assumeThat(System.getProperty("java.specification.version"))
                 .describedAs("Refaster does not currently support fluent refactors on java 11")
                 .isEqualTo("1.8");
-        RefasterTestHelper.forRefactoring(AssertjOptionalHasValue.class)
+        RefasterTestHelper.forRefactoring(AssertjOptionalContains.class)
                 .withInputLines(
                         "Test",
                         "import static org.assertj.core.api.Assertions.assertThat;",
@@ -36,11 +36,16 @@ public final class AssertjOptionalHasValueTest {
                         "public class Test<String> {",
                         "  void f(Optional<String> in, String out) {",
                         "    assertThat(in.get()).isEqualTo(out);",
+                        "    assertThat(in).isEqualTo(Optional.of(out));",
                         "    assertThat(in.isPresent() && in.get().equals(out)).isTrue();",
                         "  }",
                         "  void g(Optional<String> in, String out) {",
                         "    assertThat(in).isPresent();",
                         "    assertThat(in).hasValue(out);",
+                        "  }",
+                        "  void h(Optional<String> in, String out) {",
+                        "    assertThat(in).isPresent();",
+                        "    assertThat(in).contains(out);",
                         "  }",
                         "}")
                 .hasOutputLines(
@@ -48,11 +53,16 @@ public final class AssertjOptionalHasValueTest {
                         "import java.util.Optional;",
                         "public class Test<String> {",
                         "  void f(Optional<String> in, String out) {",
-                        "    assertThat(in).hasValue(out);",
-                        "    assertThat(in).hasValue(out);",
+                        "    assertThat(in).contains(out);",
+                        "    assertThat(in).contains(out);",
+                        "    assertThat(in).contains(out);",
                         "  }",
                         "  void g(Optional<String> in, String out) {",
-                        "    assertThat(in).hasValue(out);",
+                        "    assertThat(in).contains(out);",
+                        "    ",
+                        "  }",
+                        "  void h(Optional<String> in, String out) {",
+                        "    assertThat(in).contains(out);",
                         "    ",
                         "  }",
                         "}");
@@ -63,7 +73,7 @@ public final class AssertjOptionalHasValueTest {
         assumeThat(System.getProperty("java.specification.version"))
                 .describedAs("Refaster does not currently support fluent refactors on java 11")
                 .isEqualTo("1.8");
-        RefasterTestHelper.forRefactoring(AssertjOptionalHasValueWithDescription.class)
+        RefasterTestHelper.forRefactoring(AssertjOptionalContainsWithDescription.class)
                 .withInputLines(
                         "Test",
                         "import static org.assertj.core.api.Assertions.assertThat;",
@@ -71,6 +81,7 @@ public final class AssertjOptionalHasValueTest {
                         "public class Test<String> {",
                         "  void f(Optional<String> in, String out) {",
                         "    assertThat(in.get()).describedAs(\"desc\").isEqualTo(out);",
+                        "    assertThat(in).describedAs(\"desc\").isEqualTo(Optional.of(out));",
                         "    assertThat(in.isPresent() && in.get().equals(out)).describedAs(\"desc\").isTrue();",
                         "  }",
                         "}")
@@ -79,8 +90,9 @@ public final class AssertjOptionalHasValueTest {
                         "import java.util.Optional;",
                         "public class Test<String> {",
                         "  void f(Optional<String> in, String out) {",
-                        "    assertThat(in).describedAs(\"desc\").hasValue(out);",
-                        "    assertThat(in).describedAs(\"desc\").hasValue(out);",
+                        "    assertThat(in).describedAs(\"desc\").contains(out);",
+                        "    assertThat(in).describedAs(\"desc\").contains(out);",
+                        "    assertThat(in).describedAs(\"desc\").contains(out);",
                         "  }",
                         "}");
     }
@@ -90,23 +102,31 @@ public final class AssertjOptionalHasValueTest {
         assumeThat(System.getProperty("java.specification.version"))
                 .describedAs("Refaster does not currently support fluent refactors on java 11")
                 .isEqualTo("1.8");
-        RefasterTestHelper.forRefactoring(AssertjOptionalHasValueRedundantWithDescription.class)
+        RefasterTestHelper.forRefactoring(AssertjOptionalContainsRedundantWithDescription.class)
                 .withInputLines(
                         "Test",
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.Optional;",
                         "public class Test<String> {",
-                        "  void g(Optional<String> in, String out) {",
+                        "  void f(Optional<String> in, String out) {",
                         "    assertThat(in).describedAs(\"a\").isPresent();",
                         "    assertThat(in).describedAs(\"b\").hasValue(out);",
+                        "  }",
+                        "  void g(Optional<String> in, String out) {",
+                        "    assertThat(in).describedAs(\"a\").isPresent();",
+                        "    assertThat(in).describedAs(\"b\").contains(out);",
                         "  }",
                         "}")
                 .hasOutputLines(
                         "import static org.assertj.core.api.Assertions.assertThat;",
                         "import java.util.Optional;",
                         "public class Test<String> {",
+                        "  void f(Optional<String> in, String out) {",
+                        "    assertThat(in).describedAs(\"b\").contains(out);",
+                        "    ",
+                        "  }",
                         "  void g(Optional<String> in, String out) {",
-                        "    assertThat(in).describedAs(\"b\").hasValue(out);",
+                        "    assertThat(in).describedAs(\"b\").contains(out);",
                         "    ",
                         "  }",
                         "}");

--- a/assertj-refaster-rules/src/test/java/com/palantir/assertj/refaster/AssertjOptionalPresenceTest.java
+++ b/assertj-refaster-rules/src/test/java/com/palantir/assertj/refaster/AssertjOptionalPresenceTest.java
@@ -33,6 +33,9 @@ public class AssertjOptionalPresenceTest {
                         "public class Test {",
                         "  void f(Optional<String> in) {",
                         "    assertThat(in.isPresent()).isTrue();",
+                        "    assertThat(!in.isPresent()).isFalse();",
+                        "    assertThat(in.isEmpty()).isFalse();",
+                        "    assertThat(!in.isEmpty()).isTrue();",
                         "  }",
                         "}")
                 .hasOutputLines(
@@ -40,6 +43,9 @@ public class AssertjOptionalPresenceTest {
                         "import java.util.Optional;",
                         "public class Test {",
                         "  void f(Optional<String> in) {",
+                        "    assertThat(in).isPresent();",
+                        "    assertThat(in).isPresent();",
+                        "    assertThat(in).isPresent();",
                         "    assertThat(in).isPresent();",
                         "  }",
                         "}");
@@ -55,6 +61,9 @@ public class AssertjOptionalPresenceTest {
                         "public class Test {",
                         "  void f(Optional<String> in) {",
                         "    assertThat(in.isPresent()).describedAs(\"desc\").isTrue();",
+                        "    assertThat(!in.isPresent()).describedAs(\"desc\").isFalse();",
+                        "    assertThat(in.isEmpty()).describedAs(\"desc\").isFalse();",
+                        "    assertThat(!in.isEmpty()).describedAs(\"desc\").isTrue();",
                         "  }",
                         "}")
                 .hasOutputLines(
@@ -63,16 +72,19 @@ public class AssertjOptionalPresenceTest {
                         "public class Test {",
                         "  void f(Optional<String> in) {",
                         "    assertThat(in).describedAs(\"desc\").isPresent();",
+                        "    assertThat(in).describedAs(\"desc\").isPresent();",
+                        "    assertThat(in).describedAs(\"desc\").isPresent();",
+                        "    assertThat(in).describedAs(\"desc\").isPresent();",
                         "  }",
                         "}");
     }
 
     @Test
-    public void isNotPresent_simple() {
+    public void isEmpty_simple() {
         assumeThat(System.getProperty("java.specification.version"))
                 .describedAs("Refaster does not currently support fluent refactors on java 11")
                 .isEqualTo("1.8");
-        RefasterTestHelper.forRefactoring(AssertjOptionalIsNotPresent.class)
+        RefasterTestHelper.forRefactoring(AssertjOptionalIsEmpty.class)
                 .withInputLines(
                         "Test",
                         "import static org.assertj.core.api.Assertions.assertThat;",
@@ -81,6 +93,8 @@ public class AssertjOptionalPresenceTest {
                         "  void f(Optional<String> in) {",
                         "    assertThat(in.isPresent()).isFalse();",
                         "    assertThat(!in.isPresent()).isTrue();",
+                        "    assertThat(in.isEmpty()).isTrue();",
+                        "    assertThat(!in.isEmpty()).isFalse();",
                         "    assertThat(in).isEqualTo(Optional.empty());",
                         "    assertThat(Optional.empty()).isEqualTo(in);",
                         "  }",
@@ -90,20 +104,22 @@ public class AssertjOptionalPresenceTest {
                         "import java.util.Optional;",
                         "public class Test {",
                         "  void f(Optional<String> in) {",
-                        "    assertThat(in).isNotPresent();",
-                        "    assertThat(in).isNotPresent();",
-                        "    assertThat(in).isNotPresent();",
-                        "    assertThat(in).isNotPresent();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
+                        "    assertThat(in).isEmpty();",
                         "  }",
                         "}");
     }
 
     @Test
-    public void isNotPresent_description() {
+    public void isEmpty_description() {
         assumeThat(System.getProperty("java.specification.version"))
                 .describedAs("Refaster does not currently support fluent refactors on java 11")
                 .isEqualTo("1.8");
-        RefasterTestHelper.forRefactoring(AssertjOptionalIsNotPresentWithDescription.class)
+        RefasterTestHelper.forRefactoring(AssertjOptionalIsEmptyWithDescription.class)
                 .withInputLines(
                         "Test",
                         "import static org.assertj.core.api.Assertions.assertThat;",
@@ -112,6 +128,8 @@ public class AssertjOptionalPresenceTest {
                         "  void f(Optional<String> in) {",
                         "    assertThat(in.isPresent()).describedAs(\"desc\").isFalse();",
                         "    assertThat(!in.isPresent()).describedAs(\"desc\").isTrue();",
+                        "    assertThat(in.isEmpty()).describedAs(\"desc\").isTrue();",
+                        "    assertThat(!in.isEmpty()).describedAs(\"desc\").isFalse();",
                         "    assertThat(in).describedAs(\"desc\").isEqualTo(Optional.empty());",
                         "    assertThat(Optional.empty()).describedAs(\"desc\").isEqualTo(in);",
                         "  }",
@@ -121,10 +139,12 @@ public class AssertjOptionalPresenceTest {
                         "import java.util.Optional;",
                         "public class Test {",
                         "  void f(Optional<String> in) {",
-                        "    assertThat(in).describedAs(\"desc\").isNotPresent();",
-                        "    assertThat(in).describedAs(\"desc\").isNotPresent();",
-                        "    assertThat(in).describedAs(\"desc\").isNotPresent();",
-                        "    assertThat(in).describedAs(\"desc\").isNotPresent();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
+                        "    assertThat(in).describedAs(\"desc\").isEmpty();",
                         "  }",
                         "}");
     }


### PR DESCRIPTION
## Changes in this PR
- Use `contains` instead of `hasValue` (does not replace existing correct uses of `hasValue`)
- Use `isEmpty` instead of `isNotPresent` (does not replace existing correct uses of `isNotPresent`)
- Add a couple more before templates