### PR TITLE
Prefer per-element assertions

### DIFF
--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjCollectionAssert.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjCollectionAssert.java
@@ -1,0 +1,153 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.assertj.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.Iterables;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.Optional;
+
+@AutoService(AssertjChecker.class)
+public final class AssertjCollectionAssert implements AssertjChecker {
+
+    private static final String DESCRIPTION = "Prefer using AssertJ collection assertions instead of isEqualTo.";
+
+    private static final Matcher<ExpressionTree> mapEqualMatcher = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.assertj.core.api.AbstractMapAssert")
+            .named("isEqualTo");
+    private static final Matcher<ExpressionTree> iterableEqualMatcher = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.assertj.core.api.AbstractIterableAssert")
+            .named("isEqualTo");
+
+    private static final Matcher<ExpressionTree> mapFactoryMatcher = MethodMatchers.staticMethod()
+            .onClassAny("java.util.Map", "com.google.common.collect.ImmutableMap")
+            .named("of");
+    private static final Matcher<ExpressionTree> iterableFactoryMatcher = MethodMatchers.staticMethod()
+            .onClassAny(
+                    "java.util.List",
+                    "com.google.common.collect.ImmutableList",
+                    "java.util.Set",
+                    "com.google.common.collect.ImmutableSet")
+            .named("of");
+
+    private static final Matcher<ExpressionTree> listMatcher = Matchers.isSubtypeOf("java.util.List");
+    private static final Matcher<ExpressionTree> setMatcher = Matchers.isSubtypeOf("java.util.Set");
+
+    @Override
+    public Optional<AssertjCheckerResult> matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (mapEqualMatcher.matches(tree, state)) {
+            ExpressionTree argument = Iterables.getOnlyElement(tree.getArguments());
+
+            if (mapFactoryMatcher.matches(argument, state)) {
+                MethodInvocationTree mapFactoryTree = (MethodInvocationTree) argument;
+
+                if (mapFactoryTree.getArguments().isEmpty()) {
+                    return Optional.of(AssertjCheckerResult.builder()
+                            .description(DESCRIPTION)
+                            .fix(SuggestedFix.builder()
+                                    .merge(SuggestedFixes.renameMethodInvocation(tree, "isEmpty", state))
+                                    .replace(argument, "")
+                                    .build())
+                            .build());
+                }
+            }
+
+            return Optional.of(AssertjCheckerResult.builder()
+                    .description(DESCRIPTION)
+                    .fix(SuggestedFixes.renameMethodInvocation(tree, "containsExactlyInAnyOrderEntriesOf", state))
+                    .build());
+        }
+
+        if (iterableEqualMatcher.matches(tree, state)) {
+            ExpressionTree argument = Iterables.getOnlyElement(tree.getArguments());
+
+            IterableType iterableType = getIterableType(argument, state);
+            if (iterableType == null) {
+                return Optional.empty();
+            }
+
+            if (iterableFactoryMatcher.matches(argument, state)) {
+                MethodInvocationTree iterableFactoryTree = (MethodInvocationTree) argument;
+
+                if (iterableFactoryTree.getArguments().isEmpty()) {
+                    return Optional.of(AssertjCheckerResult.builder()
+                            .description(DESCRIPTION)
+                            .fix(SuggestedFix.builder()
+                                    .merge(SuggestedFixes.renameMethodInvocation(tree, "isEmpty", state))
+                                    .replace(argument, "")
+                                    .build())
+                            .build());
+                } else {
+                    return Optional.of(AssertjCheckerResult.builder()
+                            .description(DESCRIPTION)
+                            .fix(SuggestedFix.builder()
+                                    .merge(SuggestedFixes.renameMethodInvocation(
+                                            tree, iterableType.containsElements, state))
+                                    .replace(argument, getArgumentsSource(iterableFactoryTree, state))
+                                    .build())
+                            .build());
+                }
+            }
+
+            return Optional.of(AssertjCheckerResult.builder()
+                    .description(DESCRIPTION)
+                    .fix(SuggestedFixes.renameMethodInvocation(tree, iterableType.containsIterable, state))
+                    .build());
+        }
+
+        return Optional.empty();
+    }
+
+    private static String getArgumentsSource(MethodInvocationTree tree, VisitorState state) {
+        return state.getSourceCode()
+                .subSequence(
+                        ASTHelpers.getStartPosition(tree.getArguments().get(0)),
+                        state.getEndPosition(Iterables.getLast(tree.getArguments())))
+                .toString();
+    }
+
+    private static IterableType getIterableType(ExpressionTree tree, VisitorState state) {
+        if (listMatcher.matches(tree, state)) {
+            return IterableType.LIST;
+        } else if (setMatcher.matches(tree, state)) {
+            return IterableType.SET;
+        } else {
+            return null;
+        }
+    }
+
+    private enum IterableType {
+        LIST("containsExactly", "containsExactlyElementsOf"),
+        SET("containsExactlyInAnyOrder", "containsExactlyInAnyOrderElementsOf");
+
+        private final String containsElements;
+        private final String containsIterable;
+
+        IterableType(String containsElements, String containsIterable) {
+            this.containsElements = containsElements;
+            this.containsIterable = containsIterable;
+        }
+    }
+}

--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjCollectionAssertTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjCollectionAssertTest.java
@@ -1,0 +1,138 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.assertj.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.jupiter.api.Test;
+
+class AssertjCollectionAssertTest {
+
+    @Test
+    public void fix_map() {
+        test().addInputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableMap;",
+                        "import java.util.HashMap;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> actual, Map<String, String> expected) {",
+                        "    assertThat(actual).isEqualTo(expected);",
+                        "    assertThat(actual).isEqualTo(new HashMap<>());",
+                        "    assertThat(actual).isEqualTo(Map.of());",
+                        "    assertThat(actual).isEqualTo(ImmutableMap.of());",
+                        "    assertThat(actual).isEqualTo(Map.of(\"foo\", \"bar\"));",
+                        "    assertThat(actual).isEqualTo(ImmutableMap.of(\"foo\", \"bar\"));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableMap;",
+                        "import java.util.HashMap;",
+                        "import java.util.Map;",
+                        "public class Test {",
+                        "  void f(Map<String, String> actual, Map<String, String> expected) {",
+                        "    assertThat(actual).containsExactlyInAnyOrderEntriesOf(expected);",
+                        "    assertThat(actual).containsExactlyInAnyOrderEntriesOf(new HashMap<>());",
+                        "    assertThat(actual).isEmpty();",
+                        "    assertThat(actual).isEmpty();",
+                        "    assertThat(actual).containsExactlyInAnyOrderEntriesOf(Map.of(\"foo\", \"bar\"));",
+                        "    assertThat(actual).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(\"foo\", \"bar\"));",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_list() {
+        test().addInputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.ArrayList;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> actual, List<String> expected) {",
+                        "    assertThat(actual).isEqualTo(expected);",
+                        "    assertThat(actual).isEqualTo(new ArrayList<>());",
+                        "    assertThat(actual).isEqualTo(List.of());",
+                        "    assertThat(actual).isEqualTo(ImmutableList.of());",
+                        "    assertThat(actual).isEqualTo(List.of(\"foo\", \"bar\"));",
+                        "    assertThat(actual).isEqualTo(ImmutableList.of(\"foo\", \"bar\"));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableList;",
+                        "import java.util.ArrayList;",
+                        "import java.util.List;",
+                        "public class Test {",
+                        "  void f(List<String> actual, List<String> expected) {",
+                        "    assertThat(actual).containsExactlyElementsOf(expected);",
+                        "    assertThat(actual).containsExactlyElementsOf(new ArrayList<>());",
+                        "    assertThat(actual).isEmpty();",
+                        "    assertThat(actual).isEmpty();",
+                        "    assertThat(actual).containsExactly(\"foo\", \"bar\");",
+                        "    assertThat(actual).containsExactly(\"foo\", \"bar\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    @Test
+    public void fix_set() {
+        test().addInputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableSet;",
+                        "import java.util.HashSet;",
+                        "import java.util.Set;",
+                        "public class Test {",
+                        "  void f(Set<String> actual, Set<String> expected) {",
+                        "    assertThat(actual).isEqualTo(expected);",
+                        "    assertThat(actual).isEqualTo(new HashSet<>());",
+                        "    assertThat(actual).isEqualTo(Set.of());",
+                        "    assertThat(actual).isEqualTo(ImmutableSet.of());",
+                        "    assertThat(actual).isEqualTo(Set.of(\"foo\", \"bar\"));",
+                        "    assertThat(actual).isEqualTo(ImmutableSet.of(\"foo\", \"bar\"));",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "import com.google.common.collect.ImmutableSet;",
+                        "import java.util.HashSet;",
+                        "import java.util.Set;",
+                        "public class Test {",
+                        "  void f(Set<String> actual, Set<String> expected) {",
+                        "    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);",
+                        "    assertThat(actual).containsExactlyInAnyOrderElementsOf(new HashSet<>());",
+                        "    assertThat(actual).isEmpty();",
+                        "    assertThat(actual).isEmpty();",
+                        "    assertThat(actual).containsExactlyInAnyOrder(\"foo\", \"bar\");",
+                        "    assertThat(actual).containsExactlyInAnyOrder(\"foo\", \"bar\");",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    private RefactoringValidator test() {
+        return RefactoringValidator.of(new AssertjRefactoring(new AssertjCollectionAssert()), getClass());
+    }
+}

--- a/changelog/@unreleased/pr-360.v2.yml
+++ b/changelog/@unreleased/pr-360.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Prefer per-element assertions for iterables and maps.
+  links:
+  - https://github.com/palantir/assertj-automation/pull/360


### PR DESCRIPTION
Using per-element assertions results in better failure messages because AssertJ will pull out the unexpected and missing elements rather than just indicating the two values are not equal. This is especially useful when the objects are large and the output is less readable.

**Before:**
```
expected: ["foo", "bar"]
 but was: ["foo", "baz"]
```

**After:**
```
Expecting actual:
  ["foo", "baz"]
to contain exactly (and in same order):
  ["foo", "bar"]
but some elements were not found:
  ["bar"]
and others were not expected:
  ["baz"]
```