### PR TITLE
Refactor instanceof assertions to use isInstanceOf()

### DIFF
--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjInstanceOfAssert.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjInstanceOfAssert.java
@@ -92,7 +92,8 @@ public final class AssertjInstanceOfAssert implements AssertjChecker {
                                 ((MemberSelectTree) match.getCheck().getMethodSelect()).getExpression()),
                         state.getEndPosition(match.getCheck()),
                         String.format(
-                                negatedAssertion ? ".isNotInstanceOf(%s.class)" : ".isInstanceOf(%s.class)", expected))
+                                negatedAssertion ? ".isNotInstanceOf(%s.class)" : ".isInstanceOf(%s.class)",
+                                state.getSourceForNode(expected)))
                 .replace(target, state.getSourceForNode(actual))
                 .build();
         return Optional.of(

--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjInstanceOfAssert.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjInstanceOfAssert.java
@@ -1,0 +1,101 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.assertj.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.InstanceOfTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.ParenthesizedTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.UnaryTree;
+import java.util.Optional;
+
+@AutoService(AssertjChecker.class)
+public final class AssertjInstanceOfAssert implements AssertjChecker {
+
+    private static final String DESCRIPTION =
+            "Prefer using AssertJ fluent comparisons over logic in an assertThat statement for better "
+                    + "failure output. assertThat(a instanceof b).isTrue() failures report 'expected true' where "
+                    + "assertThat(a).isInstanceOf(b) provides the expected and actual values.";
+
+    private static final Matcher<ExpressionTree> IS_TRUE = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.assertj.core.api.Assert")
+            .named("isTrue")
+            .withNoParameters();
+
+    private static final Matcher<ExpressionTree> IS_FALSE = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.assertj.core.api.Assert")
+            .named("isFalse")
+            .withNoParameters();
+
+    private static final Matcher<ExpressionTree> BOOLEAN_ASSERT = Matchers.anyOf(IS_TRUE, IS_FALSE);
+
+    private final AssertjSingleAssertMatcher matcher = AssertjSingleAssertMatcher.of(this::match);
+
+    @Override
+    public Optional<AssertjCheckerResult> matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (BOOLEAN_ASSERT.matches(tree, state)) {
+            return matcher.matches(tree, state);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<AssertjCheckerResult> match(
+            AssertjSingleAssertMatcher.SingleAssertMatch match, VisitorState state) {
+        boolean negatedAssertion = IS_FALSE.matches(match.getCheck(), state);
+        if (!negatedAssertion && !IS_TRUE.matches(match.getCheck(), state)) {
+            return Optional.empty();
+        }
+        ExpressionTree target = match.getAssertThat().getArguments().get(0);
+        ExpressionTree instanceOfExpression = target;
+
+        if (target instanceof UnaryTree) {
+            UnaryTree unaryTree = (UnaryTree) target;
+            if (unaryTree.getExpression() instanceof ParenthesizedTree) {
+                negatedAssertion = !negatedAssertion;
+                ParenthesizedTree parenthesizedTree = (ParenthesizedTree) unaryTree.getExpression();
+                instanceOfExpression = parenthesizedTree.getExpression();
+            }
+        }
+        if (!(instanceOfExpression instanceof InstanceOfTree)) {
+            return Optional.empty();
+        }
+        InstanceOfTree instanceOfTree = (InstanceOfTree) instanceOfExpression;
+
+        ExpressionTree actual = instanceOfTree.getExpression();
+        Tree expected = instanceOfTree.getType();
+
+        SuggestedFix fix = SuggestedFix.builder()
+                .replace(
+                        state.getEndPosition(
+                                ((MemberSelectTree) match.getCheck().getMethodSelect()).getExpression()),
+                        state.getEndPosition(match.getCheck()),
+                        String.format(
+                                negatedAssertion ? ".isNotInstanceOf(%s.class)" : ".isInstanceOf(%s.class)", expected))
+                .replace(target, state.getSourceForNode(actual))
+                .build();
+        return Optional.of(
+                AssertjCheckerResult.builder().description(DESCRIPTION).fix(fix).build());
+    }
+}

--- a/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjSize.java
+++ b/assertj-error-prone/src/main/java/com/palantir/assertj/errorprone/AssertjSize.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 public final class AssertjSize implements AssertjChecker {
 
     private static final String DESCRIPTION =
-            "Prefer AsssertJ size asserts for more debugging information than simple integer comparisons.";
+            "Prefer AssertJ size asserts for more debugging information than simple integer comparisons.";
 
     private static final Matcher<ExpressionTree> sizeMatcher = Matchers.ignoreParens(Matchers.anyOf(
             MethodMatchers.instanceMethod()

--- a/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjInstanceOfAssertTest.java
+++ b/assertj-error-prone/src/test/java/com/palantir/assertj/errorprone/AssertjInstanceOfAssertTest.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.assertj.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.jupiter.api.Test;
+
+class AssertjInstanceOfAssertTest {
+
+    @Test
+    void test_instanceof() {
+        fix().addInputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(Object o) {",
+                        "    assertThat(o instanceof String).isTrue();",
+                        "    assertThat(o instanceof String).describedAs(\"desc\").isTrue();",
+                        "    assertThat(o instanceof String).isFalse();",
+                        "    assertThat(o instanceof String).describedAs(\"desc\").isFalse();",
+                        "",
+                        "    assertThat(!(o instanceof String)).isTrue();",
+                        "    assertThat(!(o instanceof String)).describedAs(\"desc\").isTrue();",
+                        "    assertThat(!(o instanceof String)).isFalse();",
+                        "    assertThat(!(o instanceof String)).describedAs(\"desc\").isFalse();",
+                        "",
+                        "    assertThat(o.toString() instanceof String).isTrue();",
+                        "  }",
+                        "}")
+                .addOutputLines(
+                        "Test.java",
+                        "import static org.assertj.core.api.Assertions.assertThat;",
+                        "public class Test {",
+                        "  void f(Object o) {",
+                        "    assertThat(o).isInstanceOf(String.class);",
+                        "    assertThat(o).describedAs(\"desc\").isInstanceOf(String.class);",
+                        "    assertThat(o).isNotInstanceOf(String.class);",
+                        "    assertThat(o).describedAs(\"desc\").isNotInstanceOf(String.class);",
+                        "",
+                        "    assertThat(o).isNotInstanceOf(String.class);",
+                        "    assertThat(o).describedAs(\"desc\").isNotInstanceOf(String.class);",
+                        "    assertThat(o).isInstanceOf(String.class);",
+                        "    assertThat(o).describedAs(\"desc\").isInstanceOf(String.class);",
+                        "",
+                        "    assertThat(o.toString()).isInstanceOf(String.class);",
+                        "  }",
+                        "}")
+                .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+    }
+
+    private RefactoringValidator fix() {
+        return RefactoringValidator.of(new AssertjRefactoring(new AssertjInstanceOfAssert()), getClass());
+    }
+}

--- a/changelog/@unreleased/pr-635.v2.yml
+++ b/changelog/@unreleased/pr-635.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Refactor instanceof assertions to use isInstanceOf()
+  links:
+  - https://github.com/palantir/assertj-automation/pull/635


### PR DESCRIPTION
## Before this PR
This repo refactors this:
```
assertTrue(capturedException instanceof SafeRuntimeException);
```

into this:

```
assertThat(capturedException instanceof SafeRuntimeException).isTrue();
```

It should take the further step and use assertj's `.isInstanceOf()` method, to produce this:

```
assertThat(capturedException).isInstanceOf(SafeRuntimeException.class);
```

See https://pl.ntr/2mB for the 27 internal instances of this I expect to be affected.

## After this PR
==COMMIT_MSG==
Refactor instanceof assertions to use isInstanceOf()
==COMMIT_MSG==

## Possible downsides?
None known